### PR TITLE
Fix the set-user scope example in Dart

### DIFF
--- a/src/includes/set-user/dart.mdx
+++ b/src/includes/set-user/dart.mdx
@@ -2,6 +2,6 @@
 import 'package:sentry/sentry.dart';
 
 Sentry.configureScope(
-  (scope) => scope.user = User(id: 1234, email: 'jane.doe@example.com'),
+  (scope) => scope.user = User(id: "1234", email: 'jane.doe@example.com'),
 );
 ```


### PR DESCRIPTION
User.id is a String. So there are missing quotation marks.